### PR TITLE
WTEL-9522: Add self to members when accepting invite

### DIFF
--- a/src/socket/conversation.ts
+++ b/src/socket/conversation.ts
@@ -784,6 +784,9 @@ export class Conversation {
       this._autoAnswerTimerId = null
     }
     this.member = wrapChannelMember(member)
+    if (!this.members.some((m) => m.id === this.member.id)) {
+      this.members.push(this.member)
+    }
     this.inviteId = null // deleted in DB
   }
 


### PR DESCRIPTION
### [WTEL-9522](https://webitel.atlassian.net/browse/WTEL-9522)

- [ + ] Bug
- [ ] Feature

## Rationale
Після transfer чату на чергу і accept у наступного оператора в cli.allConversations()[0].members цього оператора немає. У шапці чату відображається неповний список учасників. Причина у тому, що метод Conversation.setAnswered оновлює лише одиничне поле member, а масив members лишається без нового учасника, тож юзер, який щойно прийняв інвайт, відсутній у списку.

## Implementation
У setAnswered після присвоєння this.member = wrapChannelMember(member) додано push цього ж учасника у this.members.

[WTEL-9111]: https://webitel.atlassian.net/browse/WTEL-9111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WTEL-9522]: https://webitel.atlassian.net/browse/WTEL-9522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ