### PR TITLE
fix(call): add `autoAnswer` additional types check

### DIFF
--- a/src/socket/call.ts
+++ b/src/socket/call.ts
@@ -1128,10 +1128,10 @@ export class Call {
    * @returns Чи дозволена звітність.
    */
   get allowReporting(): boolean {
-    return (
-      this.hasReporting &&
-      (this.answeredAt > 0 || (!!this.params && !!this.params.autoAnswer))
-    )
+    const autoAnswer = this.params && this.params.autoAnswer
+    const isAutoAnswerTrue = autoAnswer === true || autoAnswer === 'true'
+
+    return this.hasReporting && (this.answeredAt > 0 || isAutoAnswerTrue)
   }
 
   /**

--- a/src/socket/conversation.ts
+++ b/src/socket/conversation.ts
@@ -955,7 +955,10 @@ export class Conversation {
    * @type {boolean}
    */
   get allowReporting(): boolean {
-    return (this.answeredAt > 0 || !!this._autoAnswerParam) && this.hasReporting
+    const isAutoAnswer =
+      this._autoAnswerParam === true || this._autoAnswerParam === 'true'
+
+    return (this.answeredAt > 0 || isAutoAnswer) && this.hasReporting
   }
 
   /**


### PR DESCRIPTION
- add check for `autoAnswer` queue variable in cases of `string`, `boolean`, `number`. Now `allowReporting` should return positive value in cases if hasReporting is true as `boolean` or "true" as `string`
