### PR TITLE
ci: bump version and tag on publish workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,33 +1,38 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Publish NPM
 
 on:
+  #  https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
-  build:
-
+  publish:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-        cache: 'npm'
-    - run: npm i
-    - run: npm run fix
-    - run: npm run build
-    - run: mv dist webitel-sdk
-    - run: npm publish webitel-sdk
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Bump, build and publish
+        run: |
+          npm ci
+          echo "VERSION=$(npm version patch --no-git-tag-version)" >> "$GITHUB_ENV"
+          npm run build
+          npm run release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Commit the version bump + synced version.ts back and tag the release.
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: 'chore(release): ${{ env.VERSION }} [skip ci]'
+          commit_options: '--no-verify'
+          tagging_message: ${{ env.VERSION }}
+          file_pattern: 'package.json package-lock.json src/version.ts'


### PR DESCRIPTION
Publish NPM (workflow_dispatch) now takes a release_type input (patch/minor/major), bumps package.json via npm version, builds, publishes, then commits the bump + tags vX.Y.Z back to master. Replaces the manual version bump that standard-version used to handle.

- npm ci instead of npm i; drop the npm run fix step (source is already formatted post-merge; build syncs src/version.ts)
- contents: write + checkout token so the release commit/tag can be pushed
- version persisted only after a successful publish

_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
