### PR TITLE
ci(WTEL-9812): publish via npm trusted publishing, rename to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  id-token: write # OIDC for npm trusted publishing, https://docs.npmjs.com/trusted-publishers
+  contents: write # push the version bump + tag back
 
 jobs:
   publish:
@@ -26,8 +27,6 @@ jobs:
           echo "VERSION=$(npm version patch --no-git-tag-version)" >> "$GITHUB_ENV"
           npm run build
           npm run release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Commit the version bump + synced version.ts back and tag the release.
       - uses: stefanzweifel/git-auto-commit-action@v7


### PR DESCRIPTION
Switch the publish workflow to OIDC trusted publishing (id-token: write, no NODE_AUTH_TOKEN/NPM_TOKEN), matching webitel-ui-sdk. lts/* provides Node 24 / npm 11, which supports trusted publishing (and auto-provenance). Rename node.js.yml -> publish.yml.

Refs: https://webitel.atlassian.net/browse/WTEL-9812

_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
