### PR TITLE
feat(WTEL-9812): camelCase Task.thread getter over snake_case payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "26.4.14",
       "license": "MIT",
       "dependencies": {
+        "case-anything": "3.1.2",
         "deep-copy": "1.4.2",
         "ee-ts": "1.0.2",
         "jssip": "3.13.8",
@@ -4172,6 +4173,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/case-anything": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-3.1.2.tgz",
+      "integrity": "sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/char-regex": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     }
   },
   "dependencies": {
+    "case-anything": "3.1.2",
     "deep-copy": "1.4.2",
     "ee-ts": "1.0.2",
     "jssip": "3.13.8",

--- a/src/socket/task.ts
+++ b/src/socket/task.ts
@@ -1,3 +1,4 @@
+import { camelCase } from 'case-anything'
 // NOTE: optional peer; not installed in this package. Imported for type augmentation only.
 import type { ThreadModel } from '@webitel/chat-web-sdk'
 import { ChannelType } from './agent'
@@ -6,10 +7,19 @@ import type { Client } from './client'
 import type { Form } from './form'
 
 /**
- * Превʼю чату, прикріпленого до комунікації завдання.
+ * Превʼю чату (camelCase), яке віддає геттер `Task.thread`.
  */
 export interface ThreadPreview
   extends Pick<ThreadModel, 'lastMsg' | 'members' | 'subject'> {}
+
+/**
+ * Сире превʼю чату (snake_case) — як приходить по сокету.
+ */
+export interface RawThreadPreview {
+  last_msg?: unknown
+  members?: unknown
+  subject?: string
+}
 
 export interface Reporting {
   /**
@@ -217,10 +227,11 @@ export interface MemberCommunication {
   state?: number
 
   /**
-   * Превʼю чату, прикріпленого до комунікації.
-   * @type {ThreadPreview}
+   * Сире превʼю чату (snake_case), прикріпленого до комунікації.
+   * Для camelCase-представлення використовуйте геттер `Task.thread`.
+   * @type {RawThreadPreview}
    */
-  thread?: ThreadPreview
+  thread?: RawThreadPreview
 }
 
 export interface ChannelEvent {
@@ -965,6 +976,19 @@ export class Task {
   }
 
   /**
+   * Превʼю чату в camelCase (сире значення по сокету — snake_case).
+   * @returns {ThreadPreview | undefined}
+   */
+  get thread(): ThreadPreview | undefined {
+    const raw = this.distribute.communication.thread
+    if (!raw) {
+      return undefined
+    }
+
+    return camelizeKeys(raw) as ThreadPreview
+  }
+
+  /**
    * Отримати ім'я для відображення.
    * @returns {string | null}
    */
@@ -1153,6 +1177,28 @@ export class Task {
       sync: !!sync,
     })
   }
+}
+
+/**
+ * Рекурсивно конвертує ключі обʼєкта/масиву в camelCase.
+ */
+function camelizeKeys(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(camelizeKeys)
+  }
+
+  if (input && typeof input === 'object') {
+    const res: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(
+      input as Record<string, unknown>
+    )) {
+      res[camelCase(key)] = camelizeKeys(value)
+    }
+
+    return res
+  }
+
+  return input
 }
 
 function formFields(

--- a/src/socket/task.ts
+++ b/src/socket/task.ts
@@ -1,10 +1,10 @@
-import { camelCase } from 'case-anything'
 // NOTE: optional peer; not installed in this package. Imported for type augmentation only.
 import type { ThreadModel } from '@webitel/chat-web-sdk'
 import { ChannelType } from './agent'
 import type { CallVariables } from './call'
 import type { Client } from './client'
 import type { Form } from './form'
+import { camelizeKeys } from './utils'
 
 /**
  * Превʼю чату (camelCase), яке віддає геттер `Task.thread`.
@@ -14,11 +14,12 @@ export interface ThreadPreview
 
 /**
  * Сире превʼю чату (snake_case) — як приходить по сокету.
+ * Типи значень успадковані з {@link ThreadPreview}, ключі — snake_case.
  */
 export interface RawThreadPreview {
-  last_msg?: unknown
-  members?: unknown
-  subject?: string
+  last_msg?: ThreadPreview['lastMsg']
+  members?: ThreadPreview['members']
+  subject?: ThreadPreview['subject']
 }
 
 export interface Reporting {
@@ -1177,28 +1178,6 @@ export class Task {
       sync: !!sync,
     })
   }
-}
-
-/**
- * Рекурсивно конвертує ключі обʼєкта/масиву в camelCase.
- */
-function camelizeKeys(input: unknown): unknown {
-  if (Array.isArray(input)) {
-    return input.map(camelizeKeys)
-  }
-
-  if (input && typeof input === 'object') {
-    const res: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(
-      input as Record<string, unknown>
-    )) {
-      res[camelCase(key)] = camelizeKeys(value)
-    }
-
-    return res
-  }
-
-  return input
 }
 
 function formFields(

--- a/src/socket/utils.ts
+++ b/src/socket/utils.ts
@@ -1,3 +1,30 @@
+import { camelCase } from 'case-anything'
+
+/**
+ * Рекурсивно конвертує ключі обʼєкта/масиву в camelCase.
+ * @function
+ * @param {unknown} input - Вхідне значення.
+ * @returns {unknown} - Значення з camelCase-ключами.
+ */
+export function camelizeKeys(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map(camelizeKeys)
+  }
+
+  if (input && typeof input === 'object') {
+    const res: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(
+      input as Record<string, unknown>
+    )) {
+      res[camelCase(key)] = camelizeKeys(value)
+    }
+
+    return res
+  }
+
+  return input
+}
+
 /**
  * Функція, що форматує URI WebSocket.
  * @function

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "target": "es2022",
     "lib": ["dom", "es2022"],


### PR DESCRIPTION
## Summary

Follow-up to #90. The socket delivers the chat `thread` payload as **snake_case**, but `ThreadPreview` mirrors `ThreadModel` (camelCase). This bridges the two without lying about the wire shape.

- `MemberCommunication.thread` is now typed as **`RawThreadPreview`** (snake_case) — the honest wire shape.
- New **`Task.thread` getter** returns the camelCase `ThreadPreview`, matching the existing raw-snake-field / camelCase-getter convention already used for `memberId`, `queueId`, `agentChannelId`, etc.
- Deep key conversion via **`case-anything`** (`camelizeKeys` helper — recursive, handles nested objects + arrays).

## Notes

- `moduleResolution: "bundler"` so `tsc` can resolve `case-anything`'s `exports` map (build already uses tsdown/bundler resolution).
- `case-anything` added as a runtime dep; only `camelCase` is used → tree-shaken, negligible bundle impact.

### Behavior
```
{ last_msg: { created_at: 1 }, members: [{ user_id: 2 }], subject: 'hi' }
→ { lastMsg: { createdAt: 1 }, members: [{ userId: 2 }], subject: 'hi' }
```

Verified: typecheck clean, build green, runtime conversion correct, no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)