### PR TITLE
fix: skip undefined and null items when serializing array query params

### DIFF
--- a/src/url-shim.ts
+++ b/src/url-shim.ts
@@ -37,7 +37,8 @@ export function format(urlObj: ParsedPath): string {
     }
     if (Array.isArray(value)) {
       for (const item of value) {
-        params.append(key, String(item))
+        if (item === undefined || item === null) continue;
+         params.append(key, String(item))
       }
     } else {
       params.append(key, String(value))


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
