### PR TITLE
fix: keep browser default audio processing when constraint is unset [WTEL-8287](https://webitel.atlassian.net/browse/WTEL-8287)

### DIFF
--- a/src/sip/index.ts
+++ b/src/sip/index.ts
@@ -55,19 +55,23 @@ export function buildAudioConstraints(
 ): boolean | MediaTrackConstraints {
   const { echoCancellation, noiseSuppression, autoGainControl } = processing
 
-  if (
-    echoCancellation === undefined &&
-    noiseSuppression === undefined &&
-    autoGainControl === undefined
-  ) {
+  const constraints: MediaTrackConstraints = {}
+
+  if (echoCancellation !== undefined) {
+    constraints.echoCancellation = echoCancellation
+  }
+  if (noiseSuppression !== undefined) {
+    constraints.noiseSuppression = noiseSuppression
+  }
+  if (autoGainControl !== undefined) {
+    constraints.autoGainControl = autoGainControl
+  }
+
+  if (Object.keys(constraints).length === 0) {
     return true
   }
 
-  return {
-    echoCancellation: !!echoCancellation,
-    noiseSuppression: !!noiseSuppression,
-    autoGainControl: !!autoGainControl,
-  }
+  return constraints
 }
 
 export interface CallSession {


### PR DESCRIPTION

_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
