### PR TITLE
feat(WTEL-9812): restore latency method as public

### DIFF
--- a/src/socket/client.ts
+++ b/src/socket/client.ts
@@ -1666,6 +1666,19 @@ export class Client extends EventEmitter<ClientEvents> {
     )
   }
 
+  public async latency() {
+    const ack = {
+      client_ts: 0,
+      client_ack_ts: 0,
+      server_ts: 0,
+      server_ack_ts: 0,
+    }
+
+    Object.assign(ack, await this.request(`latency_start`, ack))
+
+    return this.calculateLatency(ack)
+  }
+
   private async calculateLatency(ack: Latency) {
     ack.client_ts = Date.now()
     Object.assign(


### PR DESCRIPTION
Bring back the latency() method removed during the biome reformat (commit 082f6b6). Expose it as public so clients can trigger a latency handshake directly.

Refs: https://webitel.atlassian.net/browse/WTEL-9812

_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._
