### PR TITLE
feat: update ThreadPreview and RawThreadPreview interfaces to include 'id' field 

### DIFF
--- a/src/socket/task.ts
+++ b/src/socket/task.ts
@@ -10,16 +10,17 @@ import { camelizeKeys } from './utils'
  * Превʼю чату (camelCase), яке віддає геттер `Task.thread`.
  */
 export interface ThreadPreview
-  extends Pick<ThreadModel, 'lastMsg' | 'members' | 'subject'> {}
+  extends Pick<ThreadModel, 'id' | 'lastMsg' | 'members' | 'subject'> {}
 
 /**
  * Сире превʼю чату (snake_case) — як приходить по сокету.
  * Типи значень успадковані з {@link ThreadPreview}, ключі — snake_case.
  */
 export interface RawThreadPreview {
+  id: ThreadPreview['id']
+  members: ThreadPreview['members']
+  subject: ThreadPreview['subject']
   last_msg?: ThreadPreview['lastMsg']
-  members?: ThreadPreview['members']
-  subject?: ThreadPreview['subject']
 }
 
 export interface Reporting {


### PR DESCRIPTION
[WMSG-375](https://webitel.atlassian.net/browse/WMSG-375)

_If there is a linked issue, mention it here._

- [ ] Bug
- [ ] Feature

## Requirements

- [ ] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

- [ ] _Example task._


[WMSG-375]: https://webitel.atlassian.net/browse/WMSG-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ